### PR TITLE
Add authorization to case endpoints

### DIFF
--- a/CLTI.Diagnosis.Client/Algoritm/Services/CltiApiClient.cs
+++ b/CLTI.Diagnosis.Client/Algoritm/Services/CltiApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http.Json;
 using System.Text.Json;
+using System.Net;
 
 namespace CLTI.Diagnosis.Client.Services
 {
@@ -32,6 +33,14 @@ namespace CLTI.Diagnosis.Client.Services
                         Success = true,
                         Data = result,
                         Message = "Дані успішно збережено"
+                    };
+                }
+                else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    return new ApiResponse<SaveCaseResponse>
+                    {
+                        Success = false,
+                        Error = "Помилка авторизації"
                     };
                 }
                 else
@@ -70,7 +79,15 @@ namespace CLTI.Diagnosis.Client.Services
                         Message = "Дані успішно отримано"
                     };
                 }
-                else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    return new ApiResponse<StateServiceDto>
+                    {
+                        Success = false,
+                        Error = "Помилка авторизації"
+                    };
+                }
+                else if (response.StatusCode == HttpStatusCode.NotFound)
                 {
                     return new ApiResponse<StateServiceDto>
                     {
@@ -114,6 +131,14 @@ namespace CLTI.Diagnosis.Client.Services
                         Message = "Дані успішно оновлено"
                     };
                 }
+                else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    return new ApiResponse<SaveCaseResponse>
+                    {
+                        Success = false,
+                        Error = "Помилка авторизації"
+                    };
+                }
                 else
                 {
                     var errorContent = await response.Content.ReadAsStringAsync();
@@ -149,7 +174,15 @@ namespace CLTI.Diagnosis.Client.Services
                         Message = "Case успішно видалено"
                     };
                 }
-                else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    return new ApiResponse<bool>
+                    {
+                        Success = false,
+                        Error = "Помилка авторизації"
+                    };
+                }
+                else if (response.StatusCode == HttpStatusCode.NotFound)
                 {
                     return new ApiResponse<bool>
                     {

--- a/CLTI.Diagnosis/Controllers/CltiCaseController.cs
+++ b/CLTI.Diagnosis/Controllers/CltiCaseController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using CLTI.Diagnosis.Services;
 using CLTI.Diagnosis.Client.Algoritm.Services;
 
@@ -17,6 +18,7 @@ namespace CLTI.Diagnosis.Controllers
 
 
         [HttpPost("save")]
+        [Authorize]
         public async Task<IActionResult> SaveCase([FromBody] StateServiceDto stateData)
         {
             try
@@ -51,6 +53,7 @@ namespace CLTI.Diagnosis.Controllers
 
 
         [HttpPut("{caseId}")]
+        [Authorize]
         public async Task<IActionResult> UpdateCase(int caseId, [FromBody] StateServiceDto stateData)
         {
             try
@@ -67,6 +70,7 @@ namespace CLTI.Diagnosis.Controllers
 
 
         [HttpDelete("{caseId}")]
+        [Authorize]
         public async Task<IActionResult> DeleteCase(int caseId)
         {
             try


### PR DESCRIPTION
## Summary
- protect POST/PUT/DELETE actions in `CltiCaseController`
- detect 401 Unauthorized responses in `CltiApiClient`

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045 - SDK 9.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f3ea6643c8324ad85e756a9994833