### PR TITLE
Configure HttpClient with credentials

### DIFF
--- a/CLTI.Diagnosis.Client/Program.cs
+++ b/CLTI.Diagnosis.Client/Program.cs
@@ -1,6 +1,7 @@
 ﻿using CLTI.Diagnosis.Client.Algoritm.Services;
 using CLTI.Diagnosis.Client.Services;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.AspNetCore.Components.WebAssembly.Http;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -10,7 +11,14 @@ builder.Services.AddSingleton<StateService>();
 builder.Services.AddAuthenticationStateDeserialization();
 
 // Додаємо HTTP клієнт для API
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped(sp =>
+    new HttpClient(new WebAssemblyHttpHandler
+    {
+        Credentials = FetchCredentialsOption.Include
+    })
+    {
+        BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)
+    });
 builder.Services.AddScoped<CltiApiClient>();
 
 // Додаємо клієнтський сервіс для роботи з CLTI cases


### PR DESCRIPTION
## Summary
- configure the WebAssembly HttpClient to send credentials

## Testing
- `dotnet build CLTI.Diagnosis.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3e90341c8324be449364aceed6d5