### PR TITLE
Fix all build errors after updates

### DIFF
--- a/CLTI.Diagnosis/Components/Routes.razor
+++ b/CLTI.Diagnosis/Components/Routes.razor
@@ -1,10 +1,10 @@
-﻿@using CLTI.Diagnosis.Client.Components
+@using CLTI.Diagnosis.Client.Components
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JSRuntime
 
-<Router AppAssembly="typeof(Program).Assembly" AdditionalAssemblies="new[] { typeof(Client._Imports).Assembly }">
+<Router AppAssembly="@typeof(Program).Assembly" AdditionalAssemblies="@(new[] { typeof(Client._Imports).Assembly })">
     <Found Context="routeData">
-        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
+        <AuthorizeRouteView RouteData="routeData" DefaultLayout="@typeof(Layout.MainLayout)">
             <NotAuthorized>
                 <RedirectToLogin />
             </NotAuthorized>
@@ -13,7 +13,7 @@
     </Found>
     <NotFound>
         <PageTitle>Page Not Found</PageTitle>
-        <LayoutView Layout="typeof(Layout.MainLayout)">
+        <LayoutView Layout="@typeof(Layout.MainLayout)">
             <NotFoundComponent />
         </LayoutView>
     </NotFound>


### PR DESCRIPTION
Fix build errors in `Routes.razor` by correcting Razor syntax for C# expressions in attributes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae626e1e-1950-46e6-90f4-f928b7de451b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae626e1e-1950-46e6-90f4-f928b7de451b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

